### PR TITLE
Various corrections and update of the pipeline dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,16 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# snakemake
+.snakemake
+
+# project
+data
+resources
+results
+slurm/err
+slurm/logs
+tmp
+.Rproj.user
+*.Rproj

--- a/Snakefile
+++ b/Snakefile
@@ -119,7 +119,7 @@ eggnog = expand("results/collated/{assembler}/{source}/eggNOG/{db}.{fc}.tsv",
             source = config["read_source"])
 mapres = expand("results/assembly/{assembler}/{source}/{sample_id}/{sample_id}_R{i}.fastq.gz",
             assembler = config["assembler"], source = config["read_source"], sample_id = samples.keys(), i = [1,2])
-mapres += expand("results/report/map/{assembler}/{assembler}_{source}_map_report.html",
+mapres += expand("results/report/map/{assembler}_{source}_map_report.html",
             assembler = config["assembler"], source = config["read_source"])
 normalize = expand("results/annotation/{assembler}/{source}/{sample_id}/featureCounts/fc.{fc}.tab",
             assembler = config["assembler"], source = config["read_source"], sample_id = samples.keys(), fc=["tpm","raw"])
@@ -169,7 +169,7 @@ taxonomy_co = expand("results/collated/co-assembly/{assembler}/{assembly}/taxono
             assembly = assemblies.keys(), assembler = config["assembler"],
             fc = ["raw","tpm"])
 # Map and normalize
-map_co = expand("results/report/map/{assembler}/{assembly}_map_report.html", assembly = assemblies.keys(), assembler=config["assembler"])
+map_co = expand("results/report/map/{assembler}.{assembly}_map_report.html", assembly = assemblies.keys(), assembler=config["assembler"])
 normalize_co = expand("results/collated/co-assembly/{assembler}/{assembly}/abundance/{assembly}.{fc}.tsv",
                 assembly = assemblies.keys(), assembler = config["assembler"], fc = ["tpm","raw"])
 ### Optional blobtools output

--- a/environment.yml
+++ b/environment.yml
@@ -7,10 +7,10 @@ dependencies:
   - python=3.8
   - snakemake-minimal=6.2.1
   - biopython=1.78
-  - pandas=1.2.4
-  - multiqc=1.10.1
-  - bowtie2=2.4.2
-  - samtools=1.9
+  - pandas=1.3.4
+  - multiqc=1.11
+  - bowtie2=2.4.4
+  - samtools=1.14
   - ete3=3.1.2
   - fastuniq=1.1
   - seqtk=1.3

--- a/envs/contigtax.yaml
+++ b/envs/contigtax.yaml
@@ -4,4 +4,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - diamond == 0.9.24
   - contigtax

--- a/envs/diamond.yaml
+++ b/envs/diamond.yaml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - diamond
+  - diamond >= 2.0.13

--- a/envs/emapper.yaml
+++ b/envs/emapper.yaml
@@ -2,8 +2,9 @@ name: eggnog-mapper
 
 channels:
 - bioconda
+- conda-forge
 - defaults
 
 dependencies:
-- python=2.7
-- eggnog-mapper=2.0.1
+- boost-cpp >= 1.74.0
+- eggnog-mapper >= 2.1.6

--- a/source/rules/annotate_co.smk
+++ b/source/rules/annotate_co.smk
@@ -317,9 +317,9 @@ rule contigtax_search_co:
         fa = "results/co-assembly/{assembler}/{assembly}/final.fa"
     output:
         diamond = "results/annotation/co-assembly/{assembler}/{assembly}/taxonomy/diamond.tsv.gz",
-        logfile = "results/annotation/co-assembly/{assembler}/{assembly}/taxonomy/diamond.log",
-        out_dir = "results/annotation/co-assembly/{assembler}/{assembly}/taxonomy",
+        logfile = "results/annotation/co-assembly/{assembler}/{assembly}/taxonomy/diamond.log"
     params:
+        out_dir = "results/annotation/co-assembly/{assembler}/{assembly}/taxonomy",
         tmp_out = "$TMPDIR/{assembly}/diamond.tsv",
         tmp_log = "$TMPDIR/{assembly}/diamond.log",
         tmp_dir = "$TMPDIR/{assembly}"

--- a/source/rules/db.smk
+++ b/source/rules/db.smk
@@ -257,6 +257,30 @@ rule build_diamond_JGI:
         mv $TMPDIR/diamond.dmnd {output.db}
         """
 
+rule build_diamond_JGI_legacy:
+    input:
+        taxonmap = "resources/diamond/taxonmap.gz",
+        fasta = "resources/diamond/fasta.gz",
+        nodes = "resources/diamond/nodes.dmp"
+    output:
+        db = "resources/diamond_legacy/diamond.dmnd"
+    conda: "../../envs/contigtax.yaml"
+    params:
+        tmpdir = "$TMPDIR/diamond"
+    threads: 4
+    resources:
+        runtime = lambda wildcards, attempt: attempt**2*60*5
+    shell:
+        """
+        # Create temporary directory
+        mkdir -p $TMPDIR
+        # Create the database
+        zcat {input.fasta} | diamond makedb -d $TMPDIR/diamond -p {threads} \
+         --taxonmap {input.taxonmap} --taxonnodes {input.nodes}
+        # Move to output
+        mv $TMPDIR/diamond.dmnd {output.db}
+        """
+
 ## KEGG info ##
 rule get_kegg_files:
     output:

--- a/source/rules/map.smk
+++ b/source/rules/map.smk
@@ -49,7 +49,7 @@ rule multiqc_map_report_co:
         fc_logs = expand("results/annotation/co-assembly/{{assembler}}/{{assembly}}/featureCounts/{sample_id}.fc.tab.summary",
             sample_id = samples.keys())
     output:
-        "results/report/map/{assembler}/{assembly}_map_report.html"
+        "results/report/map/{assembler}.{assembly}_map_report.html"
     params:
         name = "{assembler}.{assembly}_map_report.html",
         tmpdir = "$TMPDIR/{assembly}"
@@ -74,7 +74,7 @@ rule bowtie_build:
         prefix = "results/map/{assembler}/{source}/{sample_id}/final.fa"
     threads: 1
     resources:
-        runtime = lambda wildcards, attempt: attempt*attempt*30
+        runtime = lambda wildcards, attempt: attempt*attempt*60
     shell:
         """
         bowtie2-build --large-index --threads {threads} {input[0]} {params.prefix}

--- a/source/rules/paired_strategy.smk
+++ b/source/rules/paired_strategy.smk
@@ -181,10 +181,10 @@ elif config["paired_strategy"] == "one_mapped":
             # Get none of the reads mapped
             samtools fastq -f 12 -1 {params.R1h} -2 {params.R2h} -s /dev/null -0 /dev/null {input}
             # Merge bam file
-            samtools merge {params.merged} {params.only_this_end} {params.only_that_end} {params.bothends}
+            samtools merge -f {params.merged} {params.only_this_end} {params.only_that_end} {params.bothends}
             # Extract fastq from merged file 
             samtools fastq -1 {params.R1f} -2 {params.R2f} -0 /dev/null {params.merged}
-            gzip {params.R1f} {params.R2f} {params.R1h} {params.R2h}
+            gzip -f {params.R1f} {params.R2f} {params.R1h} {params.R2h}
             mv {params.R1f}.gz {output.R1f}
             mv {params.R2f}.gz {output.R2f}
             mv {params.R1h}.gz {output.R1h}
@@ -231,11 +231,11 @@ elif config["paired_strategy"] == "one_mapped":
             # Get both reads mapped
             samtools view -b -F 12 {input} > {params.bothends}
             # Merge
-            samtools merge {params.merged} {params.only_this_end} {params.only_that_end} {params.bothends}
+            samtools merge -f {params.merged} {params.only_this_end} {params.only_that_end} {params.bothends}
             # Extract fastq from merged file 
             samtools fastq -1 {params.R1h} -2 {params.R2h} -0 /dev/null {params.merged}
             
-            gzip {params.tmpdir}/*.fastq
+            gzip -f {params.tmpdir}/*.fastq
             mv {params.tmpdir}/*.fastq.gz {params.outdir}
             rm {params.merged} {params.bothends} {params.only_that_end} {params.only_this_end}
             """


### PR DESCRIPTION
Hej John!

I finished running the pipeline on the pine data and I have collated a number of updates (upgraded tools' version as well as the need to set a legacy diamond index for contigtax, as it relies on diamond v0.9, while diamond is now >2.0), a few changes (added -f to ensure a smooth restart of tasks using samtools / gzip) and some corrections to the eggnog and multiqc input/outputs.