### PR TITLE
Devel

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -120,7 +120,7 @@ mmseqs_db_dir: "/sw/data/MMseqs2_data/latest/rackham"
 # what database to use for the homology filtering step by TransDecoder
 # this database is both used to filter predicted genes called and for
 # a first round of taxonomic assignment/filtering of transcripts
-transdecoder_homology_db: "UniProtKB_Swiss-Prot"
+transdecoder_homology_db: "UniRef90"
 # mmseqs_db is the database to use for the actual taxonomic assignment
 mmseqs_db: "NR"
 # extra_genomes is a file listing additional genomes to include in the

--- a/dardel/config.yaml
+++ b/dardel/config.yaml
@@ -2,23 +2,28 @@
 # this system at https://support.pdc.kth.se/doc/.
 
 # Snakemake command line options
+#resources: "mem_mb=1800000"
+cores: 128
 keep-going: True
 printshellcmds: True
 rerun-triggers: mtime
 rerun-incomplete: True
 jobs: 200
-latency-wait: 5
+local-cores: 4
+latency-wait: 300
 executor: slurm
 shadow-prefix: "$PDC_TMP"
 software-deployment-method: "apptainer"
 apptainer-args: "--bind /cfs/klemming,$PDC_TMP,/sw/data --env TMPDIR=$PDC_TMP"
+#group-components: kraken=4
 
 # The resource definitions below specify the default used by all rules unless overridden by 
 # the set-resources section
 default-resources: 
-  slurm_account: <your-slurm-account>
+  slurm_account: naiss2025-22-737
   slurm_partition: shared
   runtime: 120
+  #mem_mb_per_cpu: 1776
 
 # The set-resources section specifies the resources to use for specific rules, this overrides
 # the default resources
@@ -28,7 +33,7 @@ set-resources:
     runtime: 30
     mem_mb: 888
   mmseqs_extract_fungalDB:
-    runtime: 120
+    runtime: 240
     mem_mb: 35200
   mmseqs_convert2fasta_fungalDB:
     runtime: 60
@@ -51,32 +56,32 @@ set-resources:
     mem_mb: 35520
   # preprocess.smk
   fastq_replace_ids:
-    runtime: 60
-    mem_mb: 1776
+    runtime: 300
+    mem_mb: 17760
   fastp:
     runtime: 60
-    mem_mb: 1776
-  sortmerna:
-    runtime: 240
     mem_mb: 5328
+  sortmerna:
+    runtime: 600
+    mem_mb: 10656
   # filter.smk
   strobealign_map_fungi:
-    runtime: 30
+    runtime: 45
     mem_mb: 17760
   process_fungal_mappings:
     runtime: 60
-    mem_mb: 1776
+    mem_mb: 3552
   star_build_host:
     runtime: 1440
   star_map_host:
-    runtime: 120
+    runtime: 180
     mem_mb: 88800
   process_host_bam:
     runtime: 60
     mem_mb: 1776
   filter_fungal_reads:
-    runtime: 30
-    mem_mb: 888
+    runtime: 60
+    mem_mb: 3552
   fastq_stats:
     runtime: 30
   filter_with_kraken:
@@ -84,16 +89,19 @@ set-resources:
   # kraken.smk
   preload_kraken_db:
     #slurm_partition: main
-    runtime: 10
+    runtime: 20
     #mem_mb: 400000
   run_kraken:
     #slurm_partition: main
-    runtime: 20
+    runtime: 60
   kraken:
     #slurm_partition: main
-    runtime: 10
+    runtime: 20
   filter_with_kraken:
-    runtime: 30
+    runtime: 60
+  #extract_kraken_reads:
+    #mem_mb: 7104
+    #runtime: 120
   # annotate.smk
   transdecoder_longorfs_co:
     runtime: 60
@@ -108,15 +116,15 @@ set-resources:
     runtime: 60
     mem_mb: 3552
   mmseqs_firstpass_taxonomy_co:
-    runtime: 60
-    mem_mb: 3552
+    runtime: 1440
+    mem_mb: 63936
   mmseqs_firstpass_taxonomy:
     runtime: 60
     mem_mb: 3552
   transdecoder_predict_co:
-    runtime: 60
+    runtime: 180
     tasks: 1
-    mem_mb: 888
+    mem_mb: 28416
   mmseqs_createquerydb_co:
     runtime: 60
     mem_mb: 3552
@@ -129,34 +137,51 @@ set-resources:
     runtime: 30
     mem_mb: 888
     tasks: 1
-  mmseqs_taxonomy_co:
-    runtime: 1440
-    tasks: 20
-    mem_mb: 88800
+  mmseqs_convertali_co:
+    runtime: 80
+    mem_mb: 14208
+    tasks: 1
   featurecount:
     runtime: 60
+  featurecount_co:
+    runtime: 60
+    mem_mb: 14208
   emapper_search:
     runtime: 300
     mem_mb: 106560
   emapper_search_co:
     runtime: 300
-    mem_mb: 106560
+    mem_mb: 124320
   assign_taxonomy_co:
     mem_mb: 64000
   emapper_annotate_hits_co:
-    runtime: 30
+    runtime: 60
     mem_mb: 53280
 # assembly.smk
   trinity_normalize:
     runtime: 1440
-  trinity_co:
-    runtime: 600
-    mem_mb: 8880
+#  trinity_co:
+#    runtime: 1440
+#    mem_mb: 200000
+    #tasks: 6
+    #slurm_partition: long
+  trinity_co_inchworm_chrysalis:
+    mem_mb: 200000
+    runtime: 900
+  trinity_co_butterfly_parallel:
+    mem_mb: 8000
+    runtime: 420
+  trinity_co_butterfly_merge:
+    mem_mb: 4000
+    runtime: 30
+  trinity_co_final:
+    mem_mb: 32000
+    runtime: 1080
   megahit_co:
     mem_mb: 17000
     runtime: 600
   transabyss_co:
-    mem_mb: 17000
+    mem_mb: 34000
     runtime: 1440
   transabyss_merge_co:
     mem_mb: 17000
@@ -173,23 +198,26 @@ set-resources:
     runtime: 60
     mem_mb: 3552
   subread_index_co:
-    runtime: 60
-    mem_mb: 3552
+    runtime: 180
+    mem_mb: 7104
   subread_align_co:
     runtime: 60
-    mem_mb: 3552
+    mem_mb: 14208
   kallisto_index_co:
     runtime: 180
-    mem_mb: 1776
+    mem_mb: 28416
   kallisto_quant_co:
     runtime: 180
-    mem_mb: 1776
+    mem_mb: 14208
   kallisto_index:
     runtime: 180
     mem_mb: 1776
   kallisto_quant:
     runtime: 180
     mem_mb: 1776
+  collate_kallisto_co:
+    runtime: 120
+    mem_mb: 14208
   bowtie_co:
     runtime: 240
     mem_mb: 32000
@@ -206,10 +234,25 @@ set-resources:
   fungi_both_mapped:
     runtime: 180
     mem_mb: 7104
+  secondpass_fungal_proteins_co:
+    runtime: 600
+    mem_mb: 7104
 
 set-threads:
+  fastq_replace_ids: 10
   emapper_search_co: 60
   emapper_search: 60
   mmseqs_createtaxdb: 20
   mmseqs_secondpass_taxonomy_co: 20
   mmseqs_secondpass_taxonomy: 20
+  mmseqs_extract_fungalDB: 20
+  mmseqs_convertali_co: 8
+  #trinity_co: 64
+  trinity_co_inchworm_chrysalis: 32
+  trinity_co_butterfly_parallel: 1
+  trinity_co_butterfly_merge: 1
+  trinity_co_final: 64
+  mmseqs_firstpass_taxonomy_co: 36
+  kallisto_index_co: 16
+  transdecoder_predict_co: 8
+  collate_kallisto_co: 8

--- a/kebnekaise/config.yaml
+++ b/kebnekaise/config.yaml
@@ -143,9 +143,9 @@ set-resources:
     runtime: 60
     mem_mb: 3552
   transdecoder_predict_co:
-    runtime: 180
+    runtime: 720
     tasks: 1
-    mem_mb: 28416
+    mem_mb: 96000
   mmseqs_createquerydb_co:
     runtime: 60
     mem_mb: 3552
@@ -155,12 +155,12 @@ set-resources:
     mem_mb: 3552
     tasks: 1
   mmseqs_createtsv_first_co:
-    runtime: 30
-    mem_mb: 888
+    runtime: 60
+    mem_mb: 4000
     tasks: 1
   mmseqs_convertali_co:
-    runtime: 80
-    mem_mb: 14208
+    runtime: 1080
+    mem_mb: 16000
     tasks: 1
   featurecount:
     runtime: 60
@@ -176,8 +176,17 @@ set-resources:
   assign_taxonomy_co:
     mem_mb: 64000
   emapper_annotate_hits_co:
-    runtime: 60
+    runtime: 180
     mem_mb: 53280
+  quantify_eggnog_co:
+    runtime: 60
+    mem_mb: 16000
+  parse_featurecounts_co:
+    runtime: 20
+    mem_mb: 16000
+  secondpass_fungal_proteins_co:
+    runtime: 120
+    mem_mb: 16000
 # assembly.smk
   trinity_normalize:
     runtime: 2880
@@ -225,18 +234,24 @@ set-resources:
     mem_mb: 5328
     tasks: 6
 # map.smk
-  subread_index:
+  # subread_index:
+  #   runtime: 60
+  #   mem_mb: 3552
+  # subread_align:
+  #   runtime: 60
+  #   mem_mb: 3552
+  # subread_index_co:
+  #   runtime: 240
+  #   mem_mb: 16000
+  strobealign_index_co:
+    runtime: 20
+    mem_mb: 32000
+  strobealign_align_co:
     runtime: 60
-    mem_mb: 3552
-  subread_align:
-    runtime: 60
-    mem_mb: 3552
-  subread_index_co:
-    runtime: 240
-    mem_mb: 16000
-  subread_align_co:
-    runtime: 60
-    mem_mb: 14208
+    mem_mb: 64000
+  # subread_align_co:
+  #   runtime: 60
+  #   mem_mb: 14208
   kallisto_index_co:
     runtime: 180
     mem_mb: 64000
@@ -254,7 +269,7 @@ set-resources:
     mem_mb: 8000
   collate_kallisto_co:
     runtime: 120
-    mem_mb: 14208
+    mem_mb: 32000
   bowtie_co:
     runtime: 240
     mem_mb: 32000
@@ -284,7 +299,7 @@ set-threads:
   mmseqs_secondpass_taxonomy_co: 20
   mmseqs_secondpass_taxonomy: 20
   mmseqs_extract_fungalDB: 20
-  mmseqs_convertali_co: 8
+  mmseqs_convertali_co: 4
   #trinity_co: 24
   trinity_normalize: 10
   trinity_co_inchworm: 16
@@ -297,3 +312,4 @@ set-threads:
   kallisto_quant_co: 8
   transdecoder_predict_co: 8
   collate_kallisto_co: 8
+  parse_featurecounts_co: 4

--- a/kebnekaise/config.yaml
+++ b/kebnekaise/config.yaml
@@ -22,7 +22,7 @@ apptainer-args: >-
 # The resource definitions below specify the default used by all rules unless overridden by 
 # the set-resources section
 default-resources: 
-  slurm_account: hpc2n2025-170
+  slurm_account: <hpc2n_compute_project>
   slurm_partition: batch
   runtime: 120
   constraint: 'zen3|zen4|skylake'
@@ -97,22 +97,22 @@ set-resources:
     runtime: 20
     #constraint: zen3
     constraint: 'largemem'
-    slurm_account: hpc2n2025-185
+    slurm_account: <largemem_project>
     cores: 16
   run_kraken:
     runtime: 60
     #constraint: zen3
     constraint: 'largemem'
-    slurm_account: hpc2n2025-185
+    slurm_account: <largemem_project>
     cores: 2
   kraken:
     constraint: 'largemem'
-    slurm_account: hpc2n2025-185
+    slurm_account: <largemem_project>
     #slurm_partition: main
     runtime: 20
   kraken2:
     constraint: 'largemem'
-    slurm_account: hpc2n2025-185
+    slurm_account: <largemem_project>
     #slurm_partition: main
     #runtime: 20
   filter_with_kraken:
@@ -180,7 +180,7 @@ set-resources:
     mem_mb: 53280
   quantify_eggnog_co:
     runtime: 60
-    mem_mb: 16000
+    mem_mb: 24000
   parse_featurecounts_co:
     runtime: 20
     mem_mb: 16000
@@ -190,25 +190,18 @@ set-resources:
 # assembly.smk
   trinity_normalize:
     runtime: 2880
-    #constraint: 'zen3|zen4'
     #slurm_partition: memory
-#  trinity_co:
-#    runtime: 5760
-#    mem_mb: 1100000
-    #tasks: 6
-    #constraint: largemem
-    #slurm_account: hpc2n2025-185
   trinity_co_inchworm:
     mem_mb: 700000
     runtime: 2160
     constraint: 'largemem'
-    slurm_account: hpc2n2025-185
+    slurm_account: <largemem_project>
     #constraint: 'zen3|zen4'
   trinity_co_chrysalis:
     mem_mb: 700000
     runtime: 4320
     constraint: 'largemem'
-    slurm_account: hpc2n2025-185
+    slurm_account: <largemem_project>
     #constraint: 'zen3|zen4'
     #slurm_partition: main
   trinity_co_butterfly_parallel:
@@ -287,8 +280,8 @@ set-resources:
     runtime: 180
     mem_mb: 7104
   secondpass_fungal_proteins_co:
-    runtime: 1440
-    mem_mb: 7104
+    runtime: 4320
+    mem_mb: 16000
 
 set-threads:
   fastq_replace_ids: 10
@@ -313,3 +306,4 @@ set-threads:
   transdecoder_predict_co: 8
   collate_kallisto_co: 8
   parse_featurecounts_co: 4
+  secondpass_fungal_proteins_co: 4

--- a/kebnekaise/config.yaml
+++ b/kebnekaise/config.yaml
@@ -1,0 +1,299 @@
+# This is the configuration profile for the Dardel HPC system. Read more about
+# this system at https://support.pdc.kth.se/doc/.
+
+# Snakemake command line options
+#resources: "mem_mb=1800000"
+cores: 128
+keep-going: True
+printshellcmds: True
+rerun-triggers: mtime
+rerun-incomplete: True
+jobs: 200
+local-cores: 4
+latency-wait: 300
+executor: slurm
+shadow-prefix: "/proj/nobackup/hpc2nstor2025-081/temp"
+software-deployment-method: "apptainer"
+apptainer-args: >-
+  --bind /proj/nobackup/hpc2nstor2025-081,$TMPDIR,/dev/shm
+  --env TMPDIR=$TMPDIR
+#group-components: kraken=4
+
+# The resource definitions below specify the default used by all rules unless overridden by 
+# the set-resources section
+default-resources: 
+  slurm_account: hpc2n2025-170
+  slurm_partition: batch
+  runtime: 120
+  constraint: 'zen3|zen4|skylake'
+  #TMPDIR2: "/scratch/${USER}-trin"
+  #mem_mb_per_cpu: 1776
+
+# The set-resources section specifies the resources to use for specific rules, this overrides
+# the default resources
+set-resources:
+  # db.smk
+  filter_transcripts:
+    runtime: 30
+    mem_mb: 888
+  mmseqs_extract_fungalDB:
+    runtime: 240
+    mem_mb: 35200
+  mmseqs_convert2fasta_fungalDB:
+    runtime: 360
+    mem_mb: 18648
+  mmseqs_createseqdb:
+    runtime: 30
+    mem_mb: 6400
+  mmseqs_create_taxidmap:
+    mem_mb: 97680
+    runtime: 60
+  mmseqs_createtaxdb:
+    runtime: 60
+    ##slurm_partition: main
+    mem_mb: 250000
+  mmseqs_secondpass_taxonomy_co:
+    runtime: 240
+    mem_mb: 35520
+  mmseqs_secondpass_taxonomy:
+    runtime: 240
+    mem_mb: 35520
+  # preprocess.smk
+  fastq_replace_ids:
+    runtime: 420
+    mem_mb: 17760
+  fastp:
+    runtime: 60
+    mem_mb: 5328
+  sortmerna:
+    runtime: 960
+    mem_mb: 10656
+  fastqc:
+    runtime: 60
+  # filter.smk
+  strobealign_map_fungi:
+    runtime: 45
+    mem_mb: 17760
+  process_fungal_mappings:
+    runtime: 180
+    mem_mb: 3552
+  star_build_host:
+    runtime: 1440
+  star_map_host:
+    runtime: 240
+    mem_mb: 88800
+  process_host_bam:
+    runtime: 60
+    mem_mb: 1776
+  filter_fungal_reads:
+    runtime: 120
+    mem_mb: 3552
+  fastq_stats:
+    runtime: 30
+  filter_with_kraken:
+    runtime: 30
+  # kraken.smk
+  preload_kraken_db:
+    runtime: 20
+    #constraint: zen3
+    constraint: 'largemem'
+    slurm_account: hpc2n2025-185
+    cores: 16
+  run_kraken:
+    runtime: 60
+    #constraint: zen3
+    constraint: 'largemem'
+    slurm_account: hpc2n2025-185
+    cores: 2
+  kraken:
+    constraint: 'largemem'
+    slurm_account: hpc2n2025-185
+    #slurm_partition: main
+    runtime: 20
+  kraken2:
+    constraint: 'largemem'
+    slurm_account: hpc2n2025-185
+    #slurm_partition: main
+    #runtime: 20
+  filter_with_kraken:
+    runtime: 60
+  extract_kraken_reads:
+    mem_mb: 21312
+    runtime: 300
+  # annotate.smk
+  kraken_nohost:
+    mem_mb: 7104
+    runtime: 120
+  transdecoder_longorfs_co:
+    runtime: 180
+    mem_mb: 4000
+  transdecoder_longorfs:
+    runtime: 60
+    mem_mb: 888
+  mmseqs_createquerydb_longorfs_co:
+    runtime: 60
+    mem_mb: 8000
+  mmseqs_createquerydb_longorfs:
+    runtime: 60
+    mem_mb: 3552
+  mmseqs_firstpass_taxonomy_co:
+    runtime: 1440
+    mem_mb: 63936
+  mmseqs_firstpass_taxonomy:
+    runtime: 60
+    mem_mb: 3552
+  transdecoder_predict_co:
+    runtime: 180
+    tasks: 1
+    mem_mb: 28416
+  mmseqs_createquerydb_co:
+    runtime: 60
+    mem_mb: 3552
+    tasks: 1
+  mmseqs_addtaxonomy_co:
+    runtime: 60
+    mem_mb: 3552
+    tasks: 1
+  mmseqs_createtsv_first_co:
+    runtime: 30
+    mem_mb: 888
+    tasks: 1
+  mmseqs_convertali_co:
+    runtime: 80
+    mem_mb: 14208
+    tasks: 1
+  featurecount:
+    runtime: 60
+  featurecount_co:
+    runtime: 60
+    mem_mb: 14208
+  emapper_search:
+    runtime: 300
+    mem_mb: 106560
+  emapper_search_co:
+    runtime: 300
+    mem_mb: 124320
+  assign_taxonomy_co:
+    mem_mb: 64000
+  emapper_annotate_hits_co:
+    runtime: 60
+    mem_mb: 53280
+# assembly.smk
+  trinity_normalize:
+    runtime: 2880
+    #constraint: 'zen3|zen4'
+    #slurm_partition: memory
+#  trinity_co:
+#    runtime: 5760
+#    mem_mb: 1100000
+    #tasks: 6
+    #constraint: largemem
+    #slurm_account: hpc2n2025-185
+  trinity_co_inchworm:
+    mem_mb: 700000
+    runtime: 2160
+    constraint: 'largemem'
+    slurm_account: hpc2n2025-185
+    #constraint: 'zen3|zen4'
+  trinity_co_chrysalis:
+    mem_mb: 700000
+    runtime: 4320
+    constraint: 'largemem'
+    slurm_account: hpc2n2025-185
+    #constraint: 'zen3|zen4'
+    #slurm_partition: main
+  trinity_co_butterfly_parallel:
+    mem_mb: 8000
+    runtime: 1440
+  trinity_co_butterfly_merge:
+    mem_mb: 4000
+    runtime: 30
+  trinity_co_final:
+    mem_mb: 64000
+    runtime: 1440
+  megahit_co:
+    mem_mb: 17000
+    runtime: 600
+  transabyss_co:
+    mem_mb: 34000
+    runtime: 1440
+  transabyss_merge_co:
+    mem_mb: 17000
+    runtime: 1440
+  trinity:
+    runtime: 600
+    mem_mb: 5328
+    tasks: 6
+# map.smk
+  subread_index:
+    runtime: 60
+    mem_mb: 3552
+  subread_align:
+    runtime: 60
+    mem_mb: 3552
+  subread_index_co:
+    runtime: 240
+    mem_mb: 16000
+  subread_align_co:
+    runtime: 60
+    mem_mb: 14208
+  kallisto_index_co:
+    runtime: 180
+    mem_mb: 64000
+  kallisto_quant_co:
+    runtime: 180
+    mem_mb: 32000
+  kallisto_index:
+    runtime: 180
+    mem_mb: 1776
+  kallisto_quant:
+    runtime: 180
+    mem_mb: 1776
+  parse_kallisto_co:
+    runtime: 60
+    mem_mb: 8000
+  collate_kallisto_co:
+    runtime: 120
+    mem_mb: 14208
+  bowtie_co:
+    runtime: 240
+    mem_mb: 32000
+  bowtie:
+    runtime: 60
+  bowtie_build:
+    runtime: 60
+    mem_mb: 888
+  samtools_sort:
+    runtime: 240
+# paired_strategy.smk
+  fungi_one_mapped:
+    runtime: 180
+  fungi_both_mapped:
+    runtime: 180
+    mem_mb: 7104
+  secondpass_fungal_proteins_co:
+    runtime: 1440
+    mem_mb: 7104
+
+set-threads:
+  fastq_replace_ids: 10
+  emapper_search_co: 60
+  emapper_search: 60
+  mmseqs_createquerydb_longorfs_co: 4
+  mmseqs_createtaxdb: 20
+  mmseqs_secondpass_taxonomy_co: 20
+  mmseqs_secondpass_taxonomy: 20
+  mmseqs_extract_fungalDB: 20
+  mmseqs_convertali_co: 8
+  #trinity_co: 24
+  trinity_normalize: 10
+  trinity_co_inchworm: 16
+  trinity_co_chrysalis: 16
+  trinity_co_butterfly_parallel: 1
+  trinity_co_butterfly_merge: 1
+  trinity_co_final: 16
+  mmseqs_firstpass_taxonomy_co: 36
+  kallisto_index_co: 16
+  kallisto_quant_co: 8
+  transdecoder_predict_co: 8
+  collate_kallisto_co: 8

--- a/source/rules/annotate_co.smk
+++ b/source/rules/annotate_co.smk
@@ -1,13 +1,13 @@
 localrules:
-    mmseqs_convertali_co,
+    #mmseqs_convertali_co,
     parse_mmseqs_first_co,
     parse_mmseqs_second_co,
     firstpass_fungal_proteins_co,
-    secondpass_fungal_proteins_co,
+    #secondpass_fungal_proteins_co,
     collate_featurecount_co,
-    parse_featurecounts_co,
+    #parse_featurecounts_co,
     parse_eggnog_co,
-    quantify_eggnog_co,
+    #quantify_eggnog_co,
     sum_taxonomy_co,
     eggnog_tax_annotations,
 
@@ -79,8 +79,6 @@ rule mmseqs_firstpass_taxonomy_co:
         output=lambda wildcards, output: f"{os.path.dirname(output[0])}/{wildcards.td_db}-taxaDB",
         ranks="superkingdom,kingdom,phylum,class,order,family,genus,species",
         aln_dir=lambda wildcards, output: os.path.dirname(output.aln[0])
-    resources:
-        mem_mb=3600,
     shell:
         """
         mkdir -p {params.tmp}
@@ -109,7 +107,7 @@ rule mmseqs_convertali_co:
         alignment=lambda wildcards, input: os.path.splitext(input.alignment[0])[0]
     shell:
         """
-        mmseqs convertalis {input.query} {input.target} {params.alignment} {output.m8} --threads 1 --format-mode 0 > {log} 2>&1
+        mmseqs convertalis {input.query} {input.target} {params.alignment} {output.m8} --threads {threads} --format-mode 0 > {log} 2>&1
         """
 
 rule transdecoder_predict_co:
@@ -263,7 +261,7 @@ rule secondpass_fungal_proteins_co:
     params:
         outdir=lambda wildcards, output: os.path.dirname(output[0]),
         indir=lambda wildcards, input: os.path.dirname(input.genecall[0]),
-    shadow: "minimal"
+    shadow: "shallow"
     run:
         write_fungal_proteins(input.parsed[0], params.indir, params.outdir)
 
@@ -348,7 +346,7 @@ rule emapper_search_co:
     threads: 10
     conda: "../../envs/emapper.yaml"
     container: "docker://quay.io/biocontainers/eggnog-mapper:2.1.12--pyhdfd78af_0"
-    shadow: "minimal"
+    shadow: "shallow"
     shell:
         """
         mkdir -p {params.tmpdir}

--- a/source/rules/annotate_single.smk
+++ b/source/rules/annotate_single.smk
@@ -5,9 +5,9 @@ localrules:
     secondpass_fungal_proteins,
     collate_taxonomy,
     eggnog_merge_and_sum,
-    parse_featurecounts,
+    #parse_featurecounts,
     parse_eggnog,
-    quantify_eggnog,
+    #quantify_eggnog,
     sum_taxonomy,
 
 ##########################################
@@ -70,7 +70,7 @@ rule mmseqs_firstpass_taxonomy:
     threads: 4
     container: "docker://quay.io/biocontainers/mmseqs2:17.b804f--hd6d6fdc_0"
     conda: "../../envs/mmseqs.yaml"
-    shadow: "minimal"
+    shadow: "shallow"
     params:
         tmp = lambda wildcards: f"mmseqs_firstpass_taxonomy.{wildcards.assembler}.{wildcards.sample_id}.{wildcards.td_db}", 
         split_memory_limit = lambda wildcards, resources: int(resources.mem_mb*.8),
@@ -245,7 +245,7 @@ rule secondpass_fungal_proteins:
     params:
         outdir = lambda wildcards, output: os.path.dirname(output[0]),
         indir = lambda wildcards, input: os.path.dirname(input.genecall[0]),
-    shadow: "minimal"
+    shadow: "shallow"
     run:
         write_fungal_proteins(input.parsed[0], params.indir, params.outdir)
 
@@ -308,7 +308,7 @@ rule emapper_search:
         outdir = lambda wc, output: os.path.dirname(output[0]),
     log: "results/annotation/{assembler}/{sample_id}/eggNOG/emapper.log"
     threads: 10
-    shadow: "minimal"
+    shadow: "shallow"
     conda: "../../envs/emapper.yaml"
     container: "docker://quay.io/biocontainers/eggnog-mapper:2.1.12--pyhdfd78af_0"
     shell:

--- a/source/rules/db.smk
+++ b/source/rules/db.smk
@@ -37,7 +37,7 @@ rule init_jgi:
         cookies="resources/JGI/cookies"
     log:
         "resources/JGI/init_jgi.log"
-    shadow: "minimal"
+    shadow: "shallow"
     params:
         user_name = config["jgi_user"],
         password = config["jgi_password"]

--- a/source/rules/filter.smk
+++ b/source/rules/filter.smk
@@ -25,7 +25,7 @@ rule strobealign_map_fungi:
     params:
         tmpdir = "{sample_id}.{chunk}",
         k = config["strobealign_strobe_len"]
-    shadow: "minimal"
+    shadow: "shallow"
     container: "docker://quay.io/biocontainers/strobealign:0.15.0--h5ca1c30_1"
     threads: 6
     shell:
@@ -159,7 +159,7 @@ rule star_map_host:
         temp_stat = "{sample_id}/{sample_id}.Log.final.out",
         setting = config["star_extra_params"]
     conda: "../../envs/star.yaml"
-    shadow: "minimal"
+    shadow: "shallow"
     container: "docker://quay.io/biocontainers/star:2.7.11b--h5ca1c30_5"
     threads: 10
     shell:
@@ -240,7 +240,7 @@ rule filter_with_kraken:
     params:
         tmpdir = "{sample_id}.{paired_strategy}",
         kraken_db=config["kraken_db"]
-    shadow: "minimal"
+    shadow: "shallow"
     shell:
         """
         exec &> {log}

--- a/source/rules/preprocess.smk
+++ b/source/rules/preprocess.smk
@@ -66,7 +66,7 @@ rule fastq_replace_ids:
         R2sort = "{sample_id}_R2.sort.fastq",
         orig = "results/preprocess/replace_ids/{sample_id}.orig",
         renamed = "results/preprocess/replace_ids/{sample_id}.renamed"
-    shadow: "minimal"
+    shadow: "shallow"
     shell:
         """
         gunzip -c {input.R1} | paste - - - - | sort -k1,1 -t " " | tr "\t" "\n" > {params.R1sort}
@@ -148,7 +148,7 @@ rule sortmerna_index:
         runtime = 60
     threads: 2
     conda: "../../envs/sortmerna.yaml"
-    shadow: "minimal"
+    shadow: "shallow"
     container: "docker://quay.io/biocontainers/sortmerna:4.3.6--h9ee0642_0"
     shell:
         """
@@ -181,7 +181,7 @@ rule sortmerna:
     threads: 4
     conda:
         "../../envs/sortmerna.yaml"
-    shadow: "minimal"
+    shadow: "shallow"
     container: "docker://quay.io/biocontainers/sortmerna:4.3.6--h9ee0642_0"
     shell:
         """


### PR DESCRIPTION
Changes made:
Trinity assembly:
 - split Trinity up into single steps after assembly
 - added options --normalize_by_read_set to normalization step (had to use the main trinity function for that instead of the normalization script) and --no_bowtie for assembly steps to reduce memory load and overall time.

Others:
- modified cluster config file for dardel with increased memory/time requirements 

- added kebnekaise config file with settings used for 84 samples with relatively high fungal load 

- changed some rules from shadow: minimal to shadow: shallow to make it work on the hpc2n cluster 